### PR TITLE
Fix supported timeloop version commit hash

### DIFF
--- a/src/cosa/check_timeloop_version.py
+++ b/src/cosa/check_timeloop_version.py
@@ -6,7 +6,7 @@ logger = utils.logger
 
 
 def check_timeloop_version():
-    supported_timeloop_commit="d2e83e9"
+    supported_timeloop_commit="019f107"
     try:
         _TIMELOOP_DIR = os.path.expanduser(os.environ['TIMELOOP_DIR'])
         command = "git rev-parse --short HEAD"


### PR DESCRIPTION
Supported commit hash is erroneously an nonexistent hash.